### PR TITLE
Remove linked pylintrc and add a minimal one

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,1 +1,7 @@
-/Users/vigo/Repos/Dropbox/Files/configs/pylintrc
+[MASTER]
+# Minimal pylintrc to satisfy Heroku buildpack cache copy
+ignore=CVS
+
+[MESSAGES CONTROL]
+disable=all
+


### PR DESCRIPTION
Heroku deploys fails on a project due the non existent `.pylintrc`. This change removes the symlink and adds a `.pylintrc` file.